### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Minealex2001/ProjectTask/security/code-scanning/1](https://github.com/Minealex2001/ProjectTask/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will restrict the `GITHUB_TOKEN` permissions to `contents: read`, which is sufficient for the actions in the workflow. This ensures that the workflow adheres to the principle of least privilege and minimizes the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
